### PR TITLE
Fix Asset has disappeared while building player to 'globalgamemanagers.assets' - path 'Packages/com.unity.purchasing.udp/Runtime/UDP.dll'

### DIFF
--- a/Plugins/IngameDebugConsole/Sprites/IngameDebugConsoleSpriteAtlas.spriteatlas
+++ b/Plugins/IngameDebugConsole/Sprites/IngameDebugConsoleSpriteAtlas.spriteatlas
@@ -21,17 +21,18 @@ SpriteAtlas:
       crunchedCompression: 0
       sRGB: 1
     platformSettings:
-    - serializedVersion: 2
+    - serializedVersion: 3
       m_BuildTarget: DefaultTexturePlatform
       m_MaxTextureSize: 2048
       m_ResizeAlgorithm: 0
       m_TextureFormat: -1
-      m_TextureCompression: 0
+      m_TextureCompression: 1
       m_CompressionQuality: 50
       m_CrunchedCompression: 0
       m_AllowsAlphaSplitting: 0
       m_Overridden: 0
       m_AndroidETC2FallbackOverride: 0
+      m_ForceMaximumCompressionQuality_BC6H_BC7: 1
     packingSettings:
       serializedVersion: 2
       padding: 8
@@ -39,6 +40,8 @@ SpriteAtlas:
       allowAlphaSplitting: 0
       enableRotation: 0
       enableTightPacking: 0
+      enableAlphaDilation: 0
+    secondaryTextureSettings: {}
     variantMultiplier: 1
     packables:
     - {fileID: 2800000, guid: 7a9e374666ad6cc47807bb001844f3d8, type: 3}
@@ -55,10 +58,40 @@ SpriteAtlas:
     - {fileID: 2800000, guid: 066d3840badf4d24dba1d42b4c59b888, type: 3}
     - {fileID: 2800000, guid: 98e8e1cf8dc7dbf469617c2e40c8a944, type: 3}
     - {fileID: 2800000, guid: b3f0d976f6d6802479d6465d11b3aa68, type: 3}
-    totalSpriteSurfaceArea: 0
     bindAsDefault: 1
+    isAtlasV2: 0
+    cachedData: {fileID: 0}
   m_MasterAtlas: {fileID: 0}
-  m_PackedSprites: []
-  m_PackedSpriteNamesToIndex: []
+  m_PackedSprites:
+  - {fileID: 21300000, guid: 066d3840badf4d24dba1d42b4c59b888, type: 3}
+  - {fileID: 21300000, guid: b902f763d0e47364dae25207b7e47800, type: 3}
+  - {fileID: 21300000, guid: b3905a73a6672d9449647aaf036e23fc, type: 3}
+  - {fileID: 21300000, guid: 066c0b04be98cd348abb79add91d42bf, type: 3}
+  - {fileID: 21300000, guid: 7a9e374666ad6cc47807bb001844f3d8, type: 3}
+  - {fileID: 21300000, guid: b3f0d976f6d6802479d6465d11b3aa68, type: 3}
+  - {fileID: 21300000, guid: e04e6c970b950d946a782ea08e5f971d, type: 3}
+  - {fileID: 21300000, guid: 66305a19e3614694f868c75a982e6b68, type: 3}
+  - {fileID: 21300000, guid: a9fd8f6b461461f4a92eafc60921ee78, type: 3}
+  - {fileID: 21300000, guid: 05c7216c78d4dd34ebe2bac9c1e274d7, type: 3}
+  - {fileID: 21300000, guid: d1546f8db185caf4dafcfa58efa3ba2c, type: 3}
+  - {fileID: 21300000, guid: 5a97d5afa6254804f81b7ba956296996, type: 3}
+  - {fileID: 21300000, guid: 98e8e1cf8dc7dbf469617c2e40c8a944, type: 3}
+  - {fileID: 21300000, guid: 7f0db3cf23c93fc4eac01cb3a52388ee, type: 3}
+  m_PackedSpriteNamesToIndex:
+  - SlicedBackground
+  - IconSnapToBottomBg
+  - IconHide
+  - IconSnapToBottom
+  - IconClear
+  - SlicedBackground3
+  - SearchIcon
+  - IconError
+  - IconResizeVertialOnly
+  - IconWarning
+  - IconCollapse
+  - IconInfo
+  - SlicedBackground2
+  - IconResizeAllDirections
+  m_RenderDataMap: {}
   m_Tag: IngameDebugConsoleSpriteAtlas
   m_IsVariant: 0


### PR DESCRIPTION
Experimentally it was found out that if you set compression for atlas, the error disappears